### PR TITLE
Add example Fyers data simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-# mayfirstapp
+# Fyers Historical Data Simulator
+
+This repository contains a simple example script for fetching historical 5-minute candle data for the NSE instrument **Reliance** using the Fyers API **v3**. It also demonstrates how to simulate playback of the candle data at an adjustable speed.
+
+## Requirements
+
+- Python 3.8+
+- Fyers API credentials (client ID, redirect URI, and secret key)
+- Dependencies listed in `requirements.txt` (includes `fyers-apiv3`)
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+1. Export your Fyers API credentials as environment variables:
+
+```bash
+export FYERS_CLIENT_ID="your_client_id"
+export FYERS_REDIRECT_URI="https://your-redirect-uri"
+export FYERS_SECRET_KEY="your_secret_key"
+```
+
+2. Run the simulation script. You will be prompted to log in and provide the authentication code from Fyers:
+
+```bash
+python simulate_reliance.py
+```
+
+The script fetches Reliance historical data between the hard-coded dates (`2022-01-01` to `2022-12-31`) and prints each candle at twice the normal speed (2x). Adjust the dates or speed in `simulate_reliance.py` as needed.
+
+## Disclaimer
+
+This example is for educational purposes only and demonstrates basic usage of the Fyers API. Ensure you comply with Fyers API terms and conditions when using their services.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fyers-apiv3
+pandas

--- a/simulate_reliance.py
+++ b/simulate_reliance.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Fetch and simulate Reliance 5-minute historical data using Fyers API v3."""
+
+import os
+import time
+import pandas as pd
+from fyers_apiv3.fyersModel import FyersModel, SessionModel
+
+
+def get_fyers(client_id: str, redirect_uri: str, secret_key: str) -> FyersModel:
+    """Authenticate and return a FyersModel instance."""
+    session = SessionModel(
+        client_id=client_id,
+        secret_key=secret_key,
+        redirect_uri=redirect_uri,
+        response_type="code",
+        grant_type="authorization_code",
+    )
+    print("Open the URL below in your browser to log in and authorize:")
+    print(session.generate_authcode())
+    auth_code = input("Enter the auth code from the redirect URL: ")
+    session.set_token(auth_code)
+    token_response = session.generate_token()
+    access_token = token_response["access_token"]
+    return FyersModel(client_id=client_id, token=access_token)
+
+
+def fetch_history(fyers: FyersModel, start: str, end: str) -> pd.DataFrame:
+    """Retrieve 5-minute historical data for Reliance."""
+    response = fyers.history(
+        data={
+            "symbol": "NSE:RELIANCE-EQ",
+            "resolution": "5",
+            "date_format": "1",
+            "range_from": start,
+            "range_to": end,
+            "cont_flag": "1",
+        }
+    )
+    if response.get("s") != "ok":
+        raise RuntimeError(f"API error: {response}")
+    df = pd.DataFrame(
+        response["candles"],
+        columns=["timestamp", "open", "high", "low", "close", "volume"],
+    )
+    df["timestamp"] = pd.to_datetime(df["timestamp"], unit="s")
+    return df
+
+
+def simulate(df: pd.DataFrame, speed: float = 1.0) -> None:
+    """Print each row of data at the given speed."""
+    delay = 5.0 / speed
+    for _, row in df.iterrows():
+        print(row.to_dict())
+        time.sleep(delay)
+
+
+def main() -> None:
+    client_id = os.getenv("FYERS_CLIENT_ID")
+    redirect_uri = os.getenv("FYERS_REDIRECT_URI")
+    secret_key = os.getenv("FYERS_SECRET_KEY")
+    if not all([client_id, redirect_uri, secret_key]):
+        raise SystemExit(
+            "Set FYERS_CLIENT_ID, FYERS_REDIRECT_URI, and FYERS_SECRET_KEY environment variables"
+        )
+
+    fyers = get_fyers(client_id, redirect_uri, secret_key)
+    df = fetch_history(fyers, start="2022-01-01", end="2022-12-31")
+    simulate(df, speed=2.0)  # 2x real time
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create example script `simulate_reliance.py` for fetching and replaying Reliance historical candles
- list dependencies in `requirements.txt`
- update README with setup and usage instructions
- update to Fyers API v3

## Testing
- `python -m py_compile simulate_reliance.py`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687cf146bcd48330861d4f1f4c244100